### PR TITLE
Remove intersecting point in path and merge the two paths of default-borwser-16.svg

### DIFF
--- a/icons/desktop/default-browser-16.svg
+++ b/icons/desktop/default-browser-16.svg
@@ -1,4 +1,4 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="context-fill" d="M8 6s0-4 3.5-4S15 5 15 6c0 4.5-7 9-7 9z"/><path fill="context-fill" d="M8 6s0-4-3.5-4S1 5 1 6c0 4.5 7 9 7 9l1-6z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M8 6s0-4-3.5-4S1 5 1 6c0 4.5 7 9 7 9m0-9s0-4 3.5-4S15 5 15 6c0 4.5-7 9-7 9z"/></svg>


### PR DESCRIPTION
This will help avoiding issues like darker shades with overlapping fills with opacity and misinterpretation when generating icon fonts.

### Before and After:
<img src="https://user-images.githubusercontent.com/2102243/63224764-f6381000-c1c8-11e9-8541-d3ab425369bd.png" alt="before-default-browser-16 svg" height="200" />

<img src="https://user-images.githubusercontent.com/2102243/63224763-f59f7980-c1c8-11e9-90d1-55e568c6c25b.png" alt="after-default-browser-16 svg" height="200" />
